### PR TITLE
Stop asset_hash option

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -13,7 +13,6 @@ set :images_dir, 'images'
 configure :build do
   activate :minify_css
   activate :minify_javascript
-  activate :asset_hash
   activate :imageoptim do |options|
     options.nice = true
     options.threads = true


### PR DESCRIPTION
Sometimes we have troubles that some image paths are broken when we build site.
So we remove `asset_hash` option from config.rb.