### PR TITLE
Use string title forcibly

### DIFF
--- a/source/api/sozais.json.erb
+++ b/source/api/sozais.json.erb
@@ -1,4 +1,4 @@
 <% api_images = data.images.map do |image| %>
-  <% { title: image.id, image: "https://sozai.katsuma.tv/images/#{image.file_name}" } %>
+  <% { title: "#{image.id}", image: "https://sozai.katsuma.tv/images/#{image.file_name}" } %>
 <% end %>
 <%= api_images.to_json %>


### PR DESCRIPTION
A sozai titled "true" is used as boolean in json api.
We'll change title as string forcibly.