### PR TITLE
Add thumbnail attribute to JSON API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ Gemfile.lock
 
 # Ignore .DS_store file
 .DS_Store
+
+# Ignore thumbnails
+/source/images/th_*

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source 'https://rubygems.org'
 gem "middleman", "~>4.2.0"
 gem "middleman-imageoptim", git: 'https://github.com/katsuma/middleman-imageoptim.git'
 gem "dotenv", "~>2.2.1"
+gem "rmagick", "~>2.16.0"
 
 # Live-reloading plugin
 gem "middleman-livereload", "~> 3.4.6"

--- a/config.rb
+++ b/config.rb
@@ -4,13 +4,13 @@ configure :development do
 end
 
 set :css_dir, 'stylesheets'
-
 set :js_dir, 'javascripts'
-
 set :images_dir, 'images'
 
 # Build-specific configuration
 configure :build do
+  system 'bundle exec ruby scripts/make_thumbnail.rb'
+
   activate :minify_css
   activate :minify_javascript
   activate :imageoptim do |options|

--- a/scripts/make_thumbnail.rb
+++ b/scripts/make_thumbnail.rb
@@ -1,0 +1,26 @@
+require 'RMagick'
+
+THUMBNAIL_SIZE = 200
+image_dir = "source/images/"
+
+image_file_names = Dir::entries(image_dir).select do |file_name|
+  file_name =~ /\.(jpg|png|gif)/
+end
+
+puts "Resizing #{image_file_names.size} images"
+
+image_file_names.each_with_index do |file_name, index|
+  image = Magick::Image.read("#{image_dir}/#{file_name}").first
+  next unless image
+
+  image_type = (image.columns >= image.rows) ? :landscape : :portrait
+  geometry = (image_type == :landscape) ? "x#{THUMBNAIL_SIZE}" : THUMBNAIL_SIZE.to_s
+
+  image.change_geometry(geometry) do |cols, rows, img|
+    img.resize_to_fit!(cols, rows)
+
+    x = image_type == :landscape ? ((cols - THUMBNAIL_SIZE)/2).to_i : 0
+    y = image_type == :portrait  ? ((rows - THUMBNAIL_SIZE)/2).to_i : 0
+    img.crop!(x, y, THUMBNAIL_SIZE, THUMBNAIL_SIZE)
+  end.write("#{image_dir}/th_#{file_name}")
+end

--- a/source/api/sozais.json.erb
+++ b/source/api/sozais.json.erb
@@ -1,4 +1,5 @@
+<% image_dir = "https://sozai.katsuma.tv/images" %>
 <% api_images = data.images.map do |image| %>
-  <% { title: "#{image.id}", image: "https://sozai.katsuma.tv/images/#{image.file_name}" } %>
+  <% { title: image.id.to_s, image: "#{image_dir}/#{image.file_name}", thumbnail: "#{image_dir}/th_#{image.file_name}" } %>
 <% end %>
 <%= api_images.to_json %>


### PR DESCRIPTION
This PR adds a thumbnail of sozai image sized by `200x200`.
Thumbnail images will be generated when `middleman build` is called.