### PR TITLE
Adjust style for wide-screen user

### DIFF
--- a/src/components/Sozai/Sozai.module.css
+++ b/src/components/Sozai/Sozai.module.css
@@ -1,5 +1,5 @@
 .sozai {
-  margin: 10px 10px 20px 10px;
+  padding: 10px 10px 20px 10px;
 }
 
 .sozai .image:last-of-type {

--- a/src/components/SozaiList/SozaiList.module.css
+++ b/src/components/SozaiList/SozaiList.module.css
@@ -1,7 +1,6 @@
 .sozaiList {
   display: flex;
   flex-wrap: wrap;
-  flex-direction: column;
 }
 
 @media screen and (min-width: 800px) {


### PR DESCRIPTION
When viewed on a wide screen, images are displayed outside of the display area.
This patch solved the problem by making the following changes:
1. Changed the way spaces are taken
2. Set `flex-direction` to the default value (`row`)

| before | after |
| --- | --- |
| ![スクリーンショット 2023-01-06 17 22 57](https://user-images.githubusercontent.com/630181/210961900-f1736096-26c5-4917-b9fc-65bdcc7206ca.png) | ![スクリーンショット 2023-01-06 17 23 09](https://user-images.githubusercontent.com/630181/210961928-08c629cc-e0b2-4e8e-af06-a8378a140c79.png) |