### PR TITLE
Fix footer

### DIFF
--- a/src/components/SozaiList/SozaiList.module.css
+++ b/src/components/SozaiList/SozaiList.module.css
@@ -7,7 +7,6 @@
   .sozaiList {
     max-width: 1200px;
     margin:0 auto;
-    height: 4000px;
   }
 }
 


### PR DESCRIPTION
The footer position appears in the middle of the content because the height of the list of Sozai is fixed.

## before

![スクリーンショット 2023-01-13 13 37 30](https://user-images.githubusercontent.com/630181/212239450-d5cbfb04-fc89-423e-8dcb-065cef9d0848.png)

## after
![スクリーンショット 2023-01-13 13 44 38](https://user-images.githubusercontent.com/630181/212239436-33a082e6-1818-4f57-ab6f-2a593f7d878a.png)
